### PR TITLE
Cache fix

### DIFF
--- a/backbone.obscura.js
+++ b/backbone.obscura.js
@@ -215,7 +215,7 @@ var createFilter = require('./src/create-filter.js');
 // of the FilteredCollection object, but are not public functions.
 
 function invalidateCache() {
-  this._collection.each(function(model) {
+  this._superset.each(function(model) {
     this._filterResultCache[model.cid] = {};
   }, this);
 }

--- a/backbone.obscura.js
+++ b/backbone.obscura.js
@@ -215,9 +215,7 @@ var createFilter = require('./src/create-filter.js');
 // of the FilteredCollection object, but are not public functions.
 
 function invalidateCache() {
-  this._superset.each(function(model) {
-    this._filterResultCache[model.cid] = {};
-  }, this);
+  this._filterResultCache = {};
 }
 
 function invalidateCacheForFilter(filterName) {


### PR DESCRIPTION
Currently, invalidating the cache only invalidates cached values for the current set of filtered models, not the entire set, which leaves models that had previously been filtered out permanently gone. This pull request instead clears the whole cache.
