### PR TITLE
Make Obscura extend Backbone.Collection

### DIFF
--- a/backbone.obscura.js
+++ b/backbone.obscura.js
@@ -111,6 +111,21 @@
                     'paginated:change:page',
                     'paginated:change:numPages'
                 ];
+            var unsupportedMethods = [
+                    'add',
+                    'create',
+                    'remove',
+                    'set',
+                    'reset',
+                    'sort',
+                    'parse',
+                    'sync',
+                    'fetch',
+                    'push',
+                    'pop',
+                    'shift',
+                    'unshift'
+                ];
             _.each(filteredMethods, function (method) {
                 methods[method] = function () {
                     var result = FilteredCollection.prototype[method].apply(this._filtered, arguments);
@@ -129,7 +144,13 @@
                     return result === this._sorted ? this : result;
                 };
             });
+            _.each(unsupportedMethods, function (method) {
+                methods[method] = function () {
+                    throw new Error('Backbone.Obscura: Unsupported method: ' + method + 'called on read-only proxy');
+                };
+            });
             _.extend(Obscura.prototype, methods, Backbone.Events);
+            Obscura = Backbone.Collection.extend(Obscura.prototype);
             Obscura.FilteredCollection = FilteredCollection;
             Obscura.SortedCollection = SortedCollection;
             Obscura.PaginatedCollection = PaginatedCollection;

--- a/index.js
+++ b/index.js
@@ -81,6 +81,11 @@ var paginatedEvents = [
   'paginated:change:perPage', 'paginated:change:page', 'paginated:change:numPages'
 ];
 
+var unsupportedMethods = [
+  'add', 'create', 'remove', 'set', 'reset', 'sort', 'parse',
+  'sync', 'fetch', 'push', 'pop', 'shift', 'unshift'
+];
+
 // Extend obscura with each of the above methods, passing the call to the underlying
 // collection.
 //
@@ -110,7 +115,17 @@ _.each(sortedMethods, function(method) {
   };
 });
 
+_.each(unsupportedMethods, function(method) {
+  methods[method] = function() {
+    throw new Error("Backbone.Obscura: Unsupported method: " + method + 'called on read-only proxy');
+  };
+});
+
 _.extend(Obscura.prototype, methods, Backbone.Events);
+
+// Now that we've over-written all of the backbone collection methods, we can safely
+// inherit from backbone's Collection
+Obscura = Backbone.Collection.extend(Obscura.prototype);
 
 // Expose the other proxy types so that the user can use them on their own if they want
 Obscura.FilteredCollection = FilteredCollection;

--- a/test/test.js
+++ b/test/test.js
@@ -61,14 +61,10 @@ describe('Backbone.Obscura', function() {
     'sync', 'fetch', 'push', 'pop', 'shift', 'unshift'
   ];
 
-  var unsupportedProperties = [
-    'comparator', 'model', 'url'
-  ];
-
   describe('unsupported Backbone#Collection methods and properties', function() {
 
     it('unsupported method calls should exist', function() {
-      _.forEach(unsupportedMethods, function(method) {
+      _.each(unsupportedMethods, function(method) {
         assert.isFunction(proxy[method]);
       });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,10 @@ describe('Backbone.Obscura', function() {
 
   describe('With no options', function() {
 
+    it('should be instanceof Backbone#Collection', function() {
+      assert(proxy instanceof Backbone.Collection);
+    });
+
     it('should be the same length as the superset', function() {
       assert(proxy.length === superset.length);
     });
@@ -48,6 +52,31 @@ describe('Backbone.Obscura', function() {
 
       superset.reset([]);
       assert(_.isEqual(superset.models, proxy.models));
+    });
+
+  });
+
+  var unsupportedMethods = [
+    'add', 'create', 'remove', 'set', 'reset', 'sort', 'parse',
+    'sync', 'fetch', 'push', 'pop', 'shift', 'unshift'
+  ];
+
+  var unsupportedProperties = [
+    'comparator', 'model', 'url'
+  ];
+
+  describe('unsupported Backbone#Collection methods and properties', function() {
+
+    it('unsupported method calls should exist', function() {
+      _.forEach(unsupportedMethods, function(method) {
+        assert.isFunction(proxy[method]);
+      });
+    });
+
+    it('should throw an error on unsupported method calls', function() {
+      _.forEach(unsupportedMethods, function(method) {
+        assert.throw(proxy[method]);
+      });
     });
 
   });


### PR DESCRIPTION
Addresses: https://github.com/jmorrell/backbone.obscura/issues/17

Obscura proxies currently don't have any relation to Backbone Collections, but this can cause issues in some libraries that [check to see if the collection is an instanceof Backbone.Collection](https://github.com/gmac/backbone.epoxy/blob/master/backbone.epoxy.js#L33).

This changes Obscura proxies to inherit from `Backbone.Collection` and then overrides all of the collection methods. Those methods which modify the original collection are replaced with methods that throw an exception, which should help users avoid doing something weird.
