### PR TITLE
Prefer using collection.set when a full reset is unnecessary.

### DIFF
--- a/backbone.obscura.js
+++ b/backbone.obscura.js
@@ -290,13 +290,29 @@
                 }
                 return true;
             }
-            function execFilter() {
+            function execFilter(options) {
+                options || (options = {});
+
                 var filtered = [];
                 if (this._superset) {
                     filtered = this._superset.filter(_.bind(execFilterOnModel, this));
                 }
-                this._collection.reset(filtered);
+
+                if (options.reset) {
+                    this._collection.reset(filtered);
+                } else {
+                    this._collection.set(filtered);
+                }
+
                 this.length = this._collection.length;
+            }
+            function onReset() {
+                execFilter.call(this, { reset: true });
+            }
+            function onSort() {
+                var hasComparator = !!(this._superset && this._superset.comparator);
+
+                execFilter.call(this, { reset: hasComparator });
             }
             function onAddChange(model) {
                 this._filterResultCache[model.cid] = {};
@@ -344,7 +360,8 @@
                 this._collection = new Backbone.Collection(superset.toArray());
                 proxyCollection(this._collection, this);
                 this.resetFilters();
-                this.listenTo(this._superset, 'reset sort', execFilter);
+                this.listenTo(this._superset, 'reset', onReset);
+                this.listenTo(this._superset, 'sort', onSort);
                 this.listenTo(this._superset, 'add change', onAddChange);
                 this.listenTo(this._superset, 'remove', onModelRemove);
                 this.listenTo(this._superset, 'all', onAll);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -66,7 +66,8 @@ module.exports = function(config) {
 
     plugins: [
       'karma-mocha',
-      'karma-firefox-launcher'
+      'karma-firefox-launcher',
+      'karma-chrome-launcher'
     ]
 
   });

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "karma": "^0.12.23",
     "karma-firefox-launcher": "~0.1.0",
+    "karma-chrome-launcher": "^0.1.3",
     "karma-mocha": "~0.1.0",
     "mocha": "~1.12.0",
     "bower": "~1.3.1",

--- a/test/filtered.js
+++ b/test/filtered.js
@@ -1060,19 +1060,6 @@ describe('filtered collection', function() {
       assert(!called);
     });
 
-    it('adding a new filter triggers a reset', function() {
-      var called = false;
-
-      filtered.on('reset', function(collection) {
-        assert(collection === filtered);
-        called = true;
-      });
-
-      filtered.filterBy({ a: 2 });
-
-      assert(called);
-    });
-
   });
 
   describe('filter-specific events', function() {


### PR DESCRIPTION
Always using `reset` can be bad for performance when a filtered collection is being used to render a list. The entire list will be re-rendered any time the proxied collection is fetched, even if only a single model has an attribute change. Instead, use the collection's `set` method unless there is an explicit `reset` or the proxied collection has a comparator.
