### PR TITLE
Replace add/remove events with a single sort event when a model is changes

### DIFF
--- a/backbone.obscura.js
+++ b/backbone.obscura.js
@@ -628,9 +628,10 @@
                     }
                 }
             }
-            function onAdd(model) {
+            function onAdd(model, collection, options) {
                 var index = modelInsertIndex.call(this, model);
-                this._collection.add(model, { at: index });
+                var silent = !!options.silent;
+                this._collection.add(model, { at: index, silent: silent });
             }
             function onRemove(model) {
                 if (this.contains(model)) {
@@ -639,8 +640,9 @@
             }
             function onChange(model) {
                 if (this.contains(model) && this._collection.indexOf(model) !== modelInsertIndex.call(this, model)) {
-                    this._collection.remove(model);
-                    onAdd.call(this, model);
+                    this._collection.remove(model, { silent: true });
+                    onAdd.call(this, model, this._superset, { silent: true });
+                    this._collection.trigger('sort', this._collection);
                 }
             }
             function sort() {


### PR DESCRIPTION
When a model that exists in a obscura sorted collection changes and the change affects the sorted index of the model in the collection, the model is removed and then added to the collection. This effectively makes sure it ends up in the right place.

The problem with this approach is that downstream listeners to the collection will receive a remove followed by the add event. Some data binding libraries that work with Backbone collections (such as Epoxy) receive these events and wastefully destroy and recreate the View that is associated to the model that has changed.

The solution I came up with for this surpasses the add/remove events, and triggers a 'sort' event on the collection afterward. Subscribers to the 'sort' event typically know how to do deal with models that gets moved around in a collection. This feels a bit hacky, as we're fudging a 'sort' event, but since Obscura is essentially an extension to the Backbone collection this should be OK.

This PR seems to pass all of the established unit tests. I may need to write some to test this functionality though?

This might not be the best way to do this so it'd be great to get some input. It would also be good to hear if this solution has the potential to cause problems. I did notice that this 'sort' event eventually turns into a 'reset' event as it passes through the Filtered/Pagination collections. So this something that might need to be addressed.
