### PR TITLE
Verified require function is defined

### DIFF
--- a/backbone.obscura.js
+++ b/backbone.obscura.js
@@ -1,5 +1,5 @@
 (function (root, factory) {
-  if (typeof exports === 'object') {
+  if (typeof exports === 'object' && typeof require === 'function') {
     module.exports = factory(require('underscore'), require('backbone'));
   }
   else if (typeof define === 'function' && define.amd) {


### PR DESCRIPTION
When trying to detect mode, it checked that `model.exports` is defined and assumed that means that require is also defined. However, this is not always the case; some libraries other then `require` also define `module.exports`. I added a check to verify `require` is a function.
